### PR TITLE
chore: zentrale Konfiguration, Java 11, WAR-Plugin

### DIFF
--- a/meldedaten/pom.xml
+++ b/meldedaten/pom.xml
@@ -1,10 +1,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>scarab</groupId>
+
+    <parent>
+        <groupId>scarab</groupId>
+        <artifactId>playground</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>meldedaten</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
     <packaging>war</packaging>
+
     <name>meldedaten</name>
     <description>Prototyp Meldedaten</description>
 
@@ -48,23 +54,17 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>3.3.1</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.tomee.maven</groupId>
                     <artifactId>tomee-maven-plugin</artifactId>
                     <version>8.0.6</version>
                 </plugin>
             </plugins>
         </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,23 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <packaging>pom</packaging>
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>scarab</groupId>
-  <artifactId>playground</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
-  <name>Playground</name>
+    <groupId>scarab</groupId>
+    <artifactId>playground</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
 
-  <modules>
-    <module>meldedaten</module>
-  </modules>
+    <name>Playground</name>
+
+    <modules>
+        <module>meldedaten</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+    </properties>
 
 </project>


### PR DESCRIPTION
Zum besseren Handling der Konfigurationen und zum Verschlanken der poms
wurden allgemeine Einstellungen in die parent-pom ausgelagert. Die Java-
Version wurde auf 11 angehoben. In diesem Zusammenhang wurde auch das
WAR-Plugin auf eine aktuelle Version gehoben, damit eine Warning nicht
mehr erzeugt wird.