### PR TITLE
feature: Spotbugs integrieren

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.3.4
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
-      with:
-        java-version: 11
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Maven
+        run: mvn -B verify --file pom.xml

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/Basisdaten.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/Basisdaten.java
@@ -1,10 +1,17 @@
 package scarab.meldedaten.mifid;
 
-import javax.persistence.*;
-import java.util.Date;
+import java.io.Serializable;
+import java.time.LocalDate;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
 @Entity
-public class Basisdaten {
+public class Basisdaten implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,7 +37,7 @@ public class Basisdaten {
   private String userField2;
 
   @Column(name = "meldetag")
-  private Date meldetag;
+  private LocalDate meldetag;
 
   public long getMeldungId() {
     return meldungId;
@@ -88,11 +95,11 @@ public class Basisdaten {
     this.userField2 = userField2;
   }
 
-  public Date getMeldetag() {
+  public LocalDate getMeldetag() {
     return meldetag;
   }
 
-  public void setMeldetag(Date meldetag) {
+  public void setMeldetag(LocalDate meldetag) {
     this.meldetag = meldetag;
   }
 }

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/Historie.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/Historie.java
@@ -1,6 +1,6 @@
 package scarab.meldedaten.mifid;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 public class Historie {
 
@@ -9,7 +9,7 @@ public class Historie {
   private String wertAlt;
   private String wertNeu;
   private String benutzer;
-  private Date zeitstempel;
+  private LocalDate zeitstempel;
 
   public long getMeldungId() {
     return meldungId;
@@ -51,11 +51,11 @@ public class Historie {
     this.benutzer = benutzer;
   }
 
-  public Date getZeitstempel() {
+  public LocalDate getZeitstempel() {
     return zeitstempel;
   }
 
-  public void setZeitstempel(Date zeitstempel) {
+  public void setZeitstempel(LocalDate zeitstempel) {
     this.zeitstempel = zeitstempel;
   }
 }

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/jsf/MeldungSucheErgebnisModel.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/jsf/MeldungSucheErgebnisModel.java
@@ -1,6 +1,7 @@
 package scarab.meldedaten.mifid.jsf;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import javax.enterprise.context.SessionScoped;
 import scarab.meldedaten.mifid.Basisdaten;
@@ -10,13 +11,13 @@ public class MeldungSucheErgebnisModel implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private List<Basisdaten> ergebnis;
+  private ArrayList<Basisdaten> ergebnis;
 
   public List<Basisdaten> getErgebnis() {
     return ergebnis;
   }
 
   public void setErgebnis(List<Basisdaten> ergebnis) {
-    this.ergebnis = ergebnis;
+    this.ergebnis = new ArrayList<>(ergebnis);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,56 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
+
+        <spotbugs.version>4.2.0</spotbugs.version>
+        <findsecbugs.version>1.11.0</findsecbugs.version>
     </properties>
+
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>${spotbugs.version}</version>
+                    <configuration>
+                        <plugins>
+                            <plugin>
+                                <groupId>com.h3xstream.findsecbugs</groupId>
+                                <artifactId>findsecbugs-plugin</artifactId>
+                                <version>${findsecbugs.version}</version>
+                            </plugin>
+                        </plugins>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+
+    <profiles>
+        <profile>
+            <id>spotbugs</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
In den Buildprozess wurde das Spotbugs-Plugin integriert. Das Plugin
wird in der Parent-pom eingebunden und somit zentral bereitgestellt und
konfiguriert. Für weitere Checks wurde auch FindSecBugs eingebunden.