### PR TITLE
feature: Checkstyle integrieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # playground
 
+## Checkstyle
+
+Das Projekt nutzt eine angepasste Version der Google-Checks aus Checkstyle 8.40. Die Anpassung war erforderlich, um beim
+Check während des Builds auch die `@SuppressWarnings`-Annotationen für Checkstyle zu berücksichtigen.
+
+Konkret wurden lediglich zwei Zeilen ergänzt:
+
+* `<module name="SuppressWarningsFilter"/>` im Modul `Checker`
+* `<module name="SuppressWarningsHolder"/>` im Modul `TreeWalker`
+
+Die Checkstyle-Konfiguration wird ebenfalls in IntelliJ im Checkstyle-Plugin verwendet, damit sich Entwicklungsumgebung
+und Mavenbuild gleich verhalten.
+
 ## Modul meldedaten
 
 ### Start

--- a/google-checks-with-suppresswarnings.xml
+++ b/google-checks-with-suppresswarnings.xml
@@ -1,0 +1,368 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.org (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+    To suppress certain violations please review suppression filters.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name="Checker">
+  <property name="charset" value="UTF-8"/>
+
+  <property name="severity" value="warning"/>
+
+  <property name="fileExtensions" value="java, properties, xml"/>
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/config_filefilters.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+  <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+              default="checkstyle-suppressions.xml"/>
+    <property name="optional" value="true"/>
+  </module>
+
+  <module name="SuppressWarningsFilter"/>
+
+  <!-- Checks for whitespace                               -->
+  <!-- See http://checkstyle.org/config_whitespace.html -->
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="100"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
+
+  <module name="TreeWalker">
+    <module name="OuterTypeFilename"/>
+    <module name="IllegalTokenText">
+      <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+      <property name="format"
+                value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+      <property name="message"
+                value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+    </module>
+    <module name="AvoidEscapedUnicodeCharacters">
+      <property name="allowEscapesForControlCharacters" value="true"/>
+      <property name="allowByTailComment" value="true"/>
+      <property name="allowNonPrintableEscapes" value="true"/>
+    </module>
+    <module name="AvoidStarImport"/>
+    <module name="OneTopLevelClass"/>
+    <module name="NoLineWrap">
+      <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
+    </module>
+    <module name="EmptyBlock">
+      <property name="option" value="TEXT"/>
+      <property name="tokens"
+                value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+    </module>
+    <module name="NeedBraces">
+      <property name="tokens"
+                value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
+    </module>
+    <module name="LeftCurly">
+      <property name="tokens"
+                value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                    INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT,
+                    LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
+                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlySame"/>
+      <property name="tokens"
+                value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="option" value="alone"/>
+      <property name="tokens"
+                value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
+                                     or preceding-sibling::*[last()][self::LCURLY]]"/>
+    </module>
+    <module name="WhitespaceAfter">
+      <property name="tokens"
+                value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, DO_WHILE"/>
+    </module>
+    <module name="WhitespaceAround">
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyLambdas" value="true"/>
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptyTypes" value="true"/>
+      <property name="allowEmptyLoops" value="true"/>
+      <property name="ignoreEnhancedForColon" value="false"/>
+      <property name="tokens"
+                value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
+                    BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
+                    LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
+                    LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
+                    LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
+                    NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
+                    SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
+      <message key="ws.notFollowed"
+               value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+      <message key="ws.notPreceded"
+               value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="OneStatementPerLine"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="ArrayTypeStyle"/>
+    <module name="MissingSwitchDefault"/>
+    <module name="FallThrough"/>
+    <module name="UpperEll"/>
+    <module name="ModifierOrder"/>
+    <module name="EmptyLineSeparator">
+      <property name="tokens"
+                value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF"/>
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapDot"/>
+      <property name="tokens" value="DOT"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapComma"/>
+      <property name="tokens" value="COMMA"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/258 -->
+      <property name="id" value="SeparatorWrapEllipsis"/>
+      <property name="tokens" value="ELLIPSIS"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/259 -->
+      <property name="id" value="SeparatorWrapArrayDeclarator"/>
+      <property name="tokens" value="ARRAY_DECLARATOR"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapMethodRef"/>
+      <property name="tokens" value="METHOD_REF"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="PackageName">
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+      <message key="name.invalidPattern"
+               value="Package name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="TypeName">
+      <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    ANNOTATION_DEF, RECORD_DEF"/>
+      <message key="name.invalidPattern"
+               value="Type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MemberName">
+      <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+      <message key="name.invalidPattern"
+               value="Member name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+               value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LambdaParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+               value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="CatchParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+               value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LocalVariableName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+               value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="PatternVariableName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+               value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ClassTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+               value="Class type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordComponentName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+               value="Record component name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+               value="Record type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MethodTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+               value="Method type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="InterfaceTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+               value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="NoFinalizer"/>
+    <module name="GenericWhitespace">
+      <message key="ws.followed"
+               value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+      <message key="ws.preceded"
+               value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+      <message key="ws.illegalFollow"
+               value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+      <message key="ws.notPreceded"
+               value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="Indentation">
+      <property name="basicOffset" value="2"/>
+      <property name="braceAdjustment" value="2"/>
+      <property name="caseIndent" value="2"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="lineWrappingIndentation" value="4"/>
+      <property name="arrayInitIndent" value="2"/>
+    </module>
+    <module name="AbbreviationAsWordInName">
+      <property name="ignoreFinal" value="false"/>
+      <property name="allowedAbbreviationLength" value="0"/>
+      <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
+                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
+                    RECORD_COMPONENT_DEF"/>
+    </module>
+    <module name="OverloadMethodsDeclarationOrder"/>
+    <module name="VariableDeclarationUsageDistance"/>
+    <module name="CustomImportOrder">
+      <property name="sortImportsInGroupAlphabetically" value="true"/>
+      <property name="separateLineBetweenGroups" value="true"/>
+      <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+      <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
+    </module>
+    <module name="MethodParamPad">
+      <property name="tokens"
+                value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF"/>
+    </module>
+    <module name="NoWhitespaceBefore">
+      <property name="tokens"
+                value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
+                    LABELED_STAT, METHOD_REF"/>
+      <property name="allowLineBreaks" value="true"/>
+    </module>
+    <module name="ParenPad">
+      <property name="tokens"
+                value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+                    EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
+                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
+                    RECORD_DEF"/>
+    </module>
+    <module name="OperatorWrap">
+      <property name="option" value="NL"/>
+      <property name="tokens"
+                value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationMostCases"/>
+      <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
+                      RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationVariables"/>
+      <property name="tokens" value="VARIABLE_DEF"/>
+      <property name="allowSamelineMultipleAnnotations" value="true"/>
+    </module>
+    <module name="NonEmptyAtclauseDescription"/>
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocTagContinuationIndentation"/>
+    <module name="SummaryJavadoc">
+      <property name="forbiddenSummaryFragments"
+                value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+    </module>
+    <module name="JavadocParagraph"/>
+    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+      <property name="target"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+    </module>
+    <module name="JavadocMethod">
+      <property name="scope" value="public"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="MissingJavadocMethod">
+      <property name="scope" value="public"/>
+      <property name="minLineCount" value="2"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
+                                   COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="MissingJavadocType">
+      <property name="scope" value="protected"/>
+      <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                      RECORD_DEF, ANNOTATION_DEF"/>
+      <property name="excludeScope" value="nothing"/>
+    </module>
+    <module name="MethodName">
+      <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+      <message key="name.invalidPattern"
+               value="Method name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="SingleLineJavadoc">
+      <property name="ignoreInlineTags" value="false"/>
+    </module>
+    <module name="EmptyCatchBlock">
+      <property name="exceptionVariableName" value="expected"/>
+    </module>
+    <module name="CommentsIndentation">
+      <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
+    </module>
+    <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+    <module name="SuppressionXpathFilter">
+      <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+                default="checkstyle-xpath-suppressions.xml"/>
+      <property name="optional" value="true"/>
+    </module>
+
+    <module name="SuppressWarningsHolder"/>
+  </module>
+</module>

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/Basisdaten.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/Basisdaten.java
@@ -8,6 +8,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
+/**
+ * Basisdaten einer Meldung. In den Basisdaten sind alle allgemeinen Daten zu einer Meldung
+ * zusammengefasst (ID der Meldung, diverse Statusangaben, Transaktionsnummer, ...).
+ */
 @Entity
 public class Basisdaten implements Serializable {
 

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/Feld.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/Feld.java
@@ -1,7 +1,14 @@
 package scarab.meldedaten.mifid;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
+/**
+ * Modellklasse für Felddefinitionen.
+ */
 @Entity
 public class Feld {
 

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/Feldhinweis.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/Feldhinweis.java
@@ -1,5 +1,8 @@
 package scarab.meldedaten.mifid;
 
+/**
+ * Modellklasse für Hinweismeldungen zu Feldern.
+ */
 public class Feldhinweis {
 
   private long meldungId;

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/Historie.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/Historie.java
@@ -2,6 +2,9 @@ package scarab.meldedaten.mifid;
 
 import java.time.LocalDate;
 
+/**
+ * Modelklasse für die Historisierung von Benutzeränderungen.
+ */
 public class Historie {
 
   private long meldungId;

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/Meldedaten.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/Meldedaten.java
@@ -1,5 +1,9 @@
 package scarab.meldedaten.mifid;
 
+/**
+ * Die Meldedaten umfassen die ID der betroffenen Meldung, die ID der Feldkonfiguration und den Wert
+ * des Feldes.
+ */
 public class Meldedaten {
 
   private long meldungId;

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/Status.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/Status.java
@@ -1,7 +1,14 @@
 package scarab.meldedaten.mifid;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
+/**
+ * Model für Statusausprägungen.
+ */
 @Entity
 public class Status {
 
@@ -16,12 +23,16 @@ public class Status {
   @Column(name = "name")
   private String name;
 
-  /**
-   * Default Konstruktor
-   */
   public Status() {
   }
 
+  /**
+   * CTor mit allen Attributen.
+   *
+   * @param statusId ID des Status
+   * @param gruppe   Statusgruppe
+   * @param name     Name des Status
+   */
   public Status(int statusId, String gruppe, String name) {
     this.statusId = statusId;
     this.gruppe = gruppe;

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/jsf/MeldungDetailModel.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/jsf/MeldungDetailModel.java
@@ -1,6 +1,10 @@
 package scarab.meldedaten.mifid.jsf;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Named;
@@ -8,6 +12,9 @@ import scarab.meldedaten.mifid.Basisdaten;
 import scarab.meldedaten.mifid.Feld;
 import scarab.meldedaten.mifid.Meldedaten;
 
+/**
+ * Frontendmodel für die Detailansicht einer Meldung.
+ */
 @Named
 @RequestScoped
 public class MeldungDetailModel {
@@ -41,6 +48,12 @@ public class MeldungDetailModel {
     this.feldListe = feldListe;
   }
 
+  /**
+   * Die Methode liefert eine Liste mit Feldkonfigurationen ({@link Feld}) und den dazugehörigen
+   * Werten ({@link Meldedaten}). Die Liste ist sortiert nach der Feld-ID.
+   *
+   * @return Liste mit Feldkonfigurationen und den tatsächlichen Werten
+   */
   // TODO: Scope bzw. Auswertbarkeit prüfen, wegen erneuter Auswertung bei Action auf Detail-Seite
   public List<Entry<Feld, Meldedaten>> getFelderMitMeldedaten() {
     List<Entry<Feld, Meldedaten>> kombinierteListe;

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/jsf/MeldungSucheErgebnisModel.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/jsf/MeldungSucheErgebnisModel.java
@@ -6,6 +6,9 @@ import java.util.List;
 import javax.enterprise.context.SessionScoped;
 import scarab.meldedaten.mifid.Basisdaten;
 
+/**
+ * Frontendmodel für die Aufnahme von Suchergebnissen.
+ */
 @SessionScoped
 public class MeldungSucheErgebnisModel implements Serializable {
 

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/jsf/MeldungSucheForm.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/jsf/MeldungSucheForm.java
@@ -10,6 +10,9 @@ import javax.inject.Named;
 import scarab.meldedaten.mifid.Basisdaten;
 import scarab.meldedaten.mifid.service.MeldungService;
 
+/**
+ * FormBean für die Meldungssuche.
+ */
 @Named
 @RequestScoped
 public class MeldungSucheForm {
@@ -26,12 +29,23 @@ public class MeldungSucheForm {
   @Inject
   private MeldungDetailModel detailModel;
 
+  /**
+   * Setzt ein ggf. vorhandenes Ergebnis zurück und leitet auf die Suchmaske weiter.
+   *
+   * @return {@link #NAV_SUCHE}
+   */
   public String initialisiereSuche() {
     model.getErgebnisModel().setErgebnis(new ArrayList<>());
 
     return NAV_SUCHE;
   }
 
+  /**
+   * Führt die Suche gegen den Businessservice durch. Das Ergebnis wird im Model abgelegt. Eine
+   * Navigation wird nicht durchgeführt.
+   *
+   * @return {@code null}, um auf der aktuellen Maske zu bleiben
+   */
   public String executeSuche() {
     FacesMessage message = new FacesMessage("Suche durchgeführt.");
     FacesContext.getCurrentInstance().addMessage(null, message);
@@ -43,6 +57,13 @@ public class MeldungSucheForm {
     return null;
   }
 
+  /**
+   * Lädt die Detaildaten für die aktuell gewählte Meldung und leitet anschließend auf die
+   * Detailseite weiter.
+   *
+   * @param gewaehlteBasisdaten {@link Basisdaten} zu lesenden Meldung
+   * @return {@link #NAV_DETAIL} bei Erfolg und {@code null}, wenn keine Meldung gewählt wurde
+   */
   public String oeffneDetail(Basisdaten gewaehlteBasisdaten) {
     if (null != gewaehlteBasisdaten) {
 

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/jsf/MeldungSucheModel.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/jsf/MeldungSucheModel.java
@@ -11,6 +11,9 @@ import scarab.meldedaten.mifid.Basisdaten;
 import scarab.meldedaten.mifid.Status;
 import scarab.meldedaten.mifid.service.StatusService;
 
+/**
+ * Frontendmodel für die Suche nach Meldungen.
+ */
 @Named
 @RequestScoped
 public class MeldungSucheModel {

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/service/MeldungService.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/service/MeldungService.java
@@ -1,26 +1,38 @@
 package scarab.meldedaten.mifid.service;
 
-import scarab.meldedaten.mifid.Basisdaten;
-import scarab.meldedaten.mifid.Feld;
-import scarab.meldedaten.mifid.Meldedaten;
-
+import java.util.ArrayList;
+import java.util.List;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
-import java.util.ArrayList;
-import java.util.List;
+import scarab.meldedaten.mifid.Basisdaten;
+import scarab.meldedaten.mifid.Feld;
+import scarab.meldedaten.mifid.Meldedaten;
 
+/**
+ * Serivce für den Zugriff auf Meldedaten.
+ */
 @Stateless
 public class MeldungService {
 
   @PersistenceContext
   private EntityManager entityManager;
 
+  /**
+   * Lesen von Basisdaten anhand der übergebenen Selektionskritieren. Es werden nur die Statusfelder
+   * als Kriterium berücksichtig.
+   *
+   * @param basisdaten {@link Basisdaten} mit Selektionskritieren
+   * @return {@link List} mit {@link Basisdaten}
+   */
   public List<Basisdaten> holeBasisdatenGefiltert(Basisdaten basisdaten) {
     TypedQuery<Basisdaten> query =
         entityManager.createQuery(
-            "select b from Basisdaten b where b.statusBtg = :statusBtg and b.statusArm = :statusArm and b.statusNca = :statusNca",
+            "select b from Basisdaten b"
+                + " where b.statusBtg = :statusBtg"
+                + " and b.statusArm = :statusArm"
+                + " and b.statusNca = :statusNca",
             Basisdaten.class);
     query.setParameter("statusBtg", basisdaten.getStatusBtg());
     query.setParameter("statusArm", basisdaten.getStatusArm());
@@ -29,6 +41,12 @@ public class MeldungService {
     return query.getResultList();
   }
 
+  /**
+   * Liest alle vorhandenen Meldungsdaten zu den übergebenen {@link Basisdaten}.
+   *
+   * @param basisdaten {@link Basisdaten} für die Selektion
+   * @return {@link List} mit {@link Meldedaten}
+   */
   public List<Meldedaten> holeMeldedatenFuerBasisdaten(Basisdaten basisdaten) {
     Meldedaten feld1 = new Meldedaten();
     feld1.setFeldId(1);
@@ -57,6 +75,11 @@ public class MeldungService {
     return meldedatenListe;
   }
 
+  /**
+   * Liefert eine Liste mit allen Feldkonfigurationen sortiert nach Feld-ID.
+   *
+   * @return {@link List} mit {@link Feld}
+   */
   public List<Feld> holeFelder() {
     List<Feld> ergebnis;
 

--- a/meldedaten/src/main/java/scarab/meldedaten/mifid/service/StatusService.java
+++ b/meldedaten/src/main/java/scarab/meldedaten/mifid/service/StatusService.java
@@ -7,12 +7,21 @@ import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
 import scarab.meldedaten.mifid.Status;
 
+/**
+ * Service für den Zugriff auf die verfügbaren Statusausprägungen.
+ */
 @Stateless
 public class StatusService {
 
   @PersistenceContext
   private EntityManager entityManager;
 
+  /**
+   * Liefert eine Liste von {@link Status}, welche alle der übergebenen Gruppe zugeordnet sind.
+   *
+   * @param gruppe Name der Statusgruppe
+   * @return {@link List} mit {@link Status}
+   */
   public List<Status> getAlleStatusFuerGruppe(String gruppe) {
     TypedQuery<Status> query =
         entityManager.createQuery("select s from Status s where s.gruppe = :gruppe", Status.class);

--- a/meldedaten/src/main/java/scarab/tryout/FancyButtonBean.java
+++ b/meldedaten/src/main/java/scarab/tryout/FancyButtonBean.java
@@ -4,6 +4,9 @@ import java.io.Serializable;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Named;
 
+/**
+ * Backing Bean für den FancyButton.
+ */
 @Named
 @SessionScoped
 public class FancyButtonBean implements Serializable {

--- a/meldedaten/src/main/webapp/index.xhtml
+++ b/meldedaten/src/main/webapp/index.xhtml
@@ -1,8 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
->
+      xmlns:h="http://java.sun.com/jsf/html">
 <h:head>
     <title>Plygrnd</title>
 </h:head>

--- a/meldedaten/src/main/webapp/meldedaten/suche.xhtml
+++ b/meldedaten/src/main/webapp/meldedaten/suche.xhtml
@@ -1,80 +1,80 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-		"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-	  xmlns:h="http://java.sun.com/jsf/html"
-	  xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="http://java.sun.com/jsf/html"
+      xmlns:f="http://java.sun.com/jsf/core">
 <h:head>
-	<title>Plygrnd</title>
+    <title>Plygrnd</title>
 </h:head>
 <h:body>
-	<h:form>
-		<h:messages/>
-		<h2>
-			<h:outputText value="Selektionskriterien"/>
-		</h2>
+    <h:form>
+        <h:messages/>
+        <h2>
+            <h:outputText value="Selektionskriterien"/>
+        </h2>
 
-		<h:outputLabel value="Status BTG"/>
-		<h:selectOneMenu value="#{meldungSucheModel.basisdaten.statusBtg}">
-			<f:selectItems value="#{meldungSucheModel.statusBtgListe}" var="item"
-						   itemLabel="#{item.name}" itemValue="#{item.statusId}"/>
-		</h:selectOneMenu>
-		<br/>
+        <h:outputLabel value="Status BTG"/>
+        <h:selectOneMenu value="#{meldungSucheModel.basisdaten.statusBtg}">
+            <f:selectItems value="#{meldungSucheModel.statusBtgListe}" var="item"
+                           itemLabel="#{item.name}" itemValue="#{item.statusId}"/>
+        </h:selectOneMenu>
+        <br/>
 
-		<h:outputLabel value="Status ARM"/>
-		<h:selectOneMenu value="#{meldungSucheModel.basisdaten.statusArm}">
-			<f:selectItems value="#{meldungSucheModel.statusArmListe}" var="item"
-						   itemLabel="#{item.name}" itemValue="#{item.statusId}"/>
-		</h:selectOneMenu>
-		<br/>
+        <h:outputLabel value="Status ARM"/>
+        <h:selectOneMenu value="#{meldungSucheModel.basisdaten.statusArm}">
+            <f:selectItems value="#{meldungSucheModel.statusArmListe}" var="item"
+                           itemLabel="#{item.name}" itemValue="#{item.statusId}"/>
+        </h:selectOneMenu>
+        <br/>
 
-		<h:outputLabel value="Status NCA"/>
-		<h:selectOneMenu value="#{meldungSucheModel.basisdaten.statusNca}">
-			<f:selectItems value="#{meldungSucheModel.statusNcaListe}" var="item"
-						   itemLabel="#{item.name}" itemValue="#{item.statusId}"/>
-		</h:selectOneMenu>
-		<br/>
+        <h:outputLabel value="Status NCA"/>
+        <h:selectOneMenu value="#{meldungSucheModel.basisdaten.statusNca}">
+            <f:selectItems value="#{meldungSucheModel.statusNcaListe}" var="item"
+                           itemLabel="#{item.name}" itemValue="#{item.statusId}"/>
+        </h:selectOneMenu>
+        <br/>
 
-		<h:outputLabel value="Transaktionsnummer"/>
-		<h:inputText
-				value="#{meldungSucheModel.basisdaten.transaktionsnummer}"/>
-		<br/>
+        <h:outputLabel value="Transaktionsnummer"/>
+        <h:inputText
+                value="#{meldungSucheModel.basisdaten.transaktionsnummer}"/>
+        <br/>
 
-		<h:outputLabel value="User-Field-3"/>
-		<h:inputText value="#{meldungSucheModel.basisdaten.userField3}"/>
-		<br/>
+        <h:outputLabel value="User-Field-3"/>
+        <h:inputText value="#{meldungSucheModel.basisdaten.userField3}"/>
+        <br/>
 
-		<h:outputLabel value="User-Field-2"/>
-		<h:inputText value="#{meldungSucheModel.basisdaten.userField2}"/>
-		<br/>
+        <h:outputLabel value="User-Field-2"/>
+        <h:inputText value="#{meldungSucheModel.basisdaten.userField2}"/>
+        <br/>
 
-		<h:commandButton action="#{meldungSucheForm.executeSuche}"
-						 value="Suchen"/>
-		<br/>
+        <h:commandButton action="#{meldungSucheForm.executeSuche}"
+                         value="Suchen"/>
+        <br/>
 
-		<h2>Ergebnis</h2>
-		<h:dataTable value="#{meldungSucheModel.ergebnisModel.ergebnis}" var="row">
-			<h:column>
-				<f:facet name="header">Transaktionsnummer</f:facet>
-				<h:outputText value="#{row.transaktionsnummer}"/>
-			</h:column>
-			<h:column>
-				<f:facet name="header">User-Field-3</f:facet>
-				<h:outputText value="#{row.userField3}"/>
-			</h:column>
-			<h:column>
-				<f:facet name="header">User-Field-2</f:facet>
-				<h:outputText value="#{row.userField2}"/>
-			</h:column>
-			<h:column>
-				<f:facet name="header">Meldetag</f:facet>
-				<h:outputText value="#{row.meldetag}"/>
-			</h:column>
-			<h:column>
-				<h:commandLink action="#{meldungSucheForm.oeffneDetail(row)}" value="Detail">
-					<f:param name="gewaehlteId" value="#{row.meldungId}"/>
-				</h:commandLink>
-			</h:column>
-		</h:dataTable>
-	</h:form>
+        <h2>Ergebnis</h2>
+        <h:dataTable value="#{meldungSucheModel.ergebnisModel.ergebnis}" var="row">
+            <h:column>
+                <f:facet name="header">Transaktionsnummer</f:facet>
+                <h:outputText value="#{row.transaktionsnummer}"/>
+            </h:column>
+            <h:column>
+                <f:facet name="header">User-Field-3</f:facet>
+                <h:outputText value="#{row.userField3}"/>
+            </h:column>
+            <h:column>
+                <f:facet name="header">User-Field-2</f:facet>
+                <h:outputText value="#{row.userField2}"/>
+            </h:column>
+            <h:column>
+                <f:facet name="header">Meldetag</f:facet>
+                <h:outputText value="#{row.meldetag}"/>
+            </h:column>
+            <h:column>
+                <h:commandLink action="#{meldungSucheForm.oeffneDetail(row)}" value="Detail">
+                    <f:param name="gewaehlteId" value="#{row.meldungId}"/>
+                </h:commandLink>
+            </h:column>
+        </h:dataTable>
+    </h:form>
 </h:body>
 </html>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
 
+        <checkstyle.version>8.40</checkstyle.version>
         <spotbugs.version>4.2.0</spotbugs.version>
         <findsecbugs.version>1.11.0</findsecbugs.version>
     </properties>
@@ -27,6 +28,24 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>3.1.2</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>${checkstyle.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <configLocation>google-checks-with-suppresswarnings.xml</configLocation>
+                        <!-- <configLocation>google_checks.xml</configLocation> -->
+                        <!-- google-checks habe nur die severity "warning" -->
+                        <violationSeverity>warning</violationSeverity>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
@@ -47,6 +66,27 @@
 
 
     <profiles>
+        <profile>
+            <id>checkstyle</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>spotbugs</id>
             <activation>


### PR DESCRIPTION
Es wurde das Checkstyle-Plugin für den Build hinzugefügt. Da die
aktuelle Version des Maven-Plugins nicht die aktuelle Checkstyleversion
nutzt, wurde diese (8.40) zusätzlich konfiguriert. Weiterhin wurde eine
angepasste Version der Google-Checks ergänzt, welche es ermöglicht, mit
Annotationen Checkstylewarnungen zu unterdrücken (siehe README). Damit
der Build erfolgreich durchlaufen werden kann, wurden alle aufgetretenen
Checkstylefehler bereiningt.